### PR TITLE
Show watched stats from PlexWWWatch on episodes and movies

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -44,6 +44,13 @@ input[type=radio] + label, input[type=checkbox] + label{
     cursor: pointer;
 }
 
+input[type=text] {
+    color: #FFF;
+    border: 1px solid #E69533;
+    background-color: #000;
+    font-size: 20px;
+}
+
 #rotten-tomatoes-audience-div {
     padding-top: 17px; /*dirty hack to fix alignment*/
     margin-right: 50px;
@@ -58,7 +65,7 @@ input[type=radio]:checked + label, input[type=checkbox]:checked + label {
 }
 
 #save {
-    float: left; 
+    float: left;
     clear: both;
     margin-top: 50px;
     margin-left: 110px;

--- a/main.js
+++ b/main.js
@@ -92,6 +92,24 @@ function getJSON(json_link) {
     return json_resp;
 }
 
+function getAsyncJSON(url, cb) {
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", url, true);
+    xhr.onload = function (e) {
+        if (xhr.readyState === 4) {
+            if (xhr.status === 200) {
+                cb(null, JSON.parse(xhr.responseText));
+            } else {
+                cb(xhr.statusText);
+            }
+        }
+    };
+    xhr.onerror = function () {
+        cb(xhr.statusText);
+    }
+    xhr.send();
+}
+
 function readFile(file_name) {
     var text;
     var rawFile = new XMLHttpRequest();
@@ -371,6 +389,9 @@ function main() {
                     debug("trakt plugin is disabled");
                 }
             });
+
+            // plexwatch
+            PlexWWWatch.doit(parent_item_id);
         }
         else if (metadata_xml.getElementsByTagName("MediaContainer")[0].getElementsByTagName("Video")[0].getAttribute("type") === "episode") {
             // we're on an episode page
@@ -386,6 +407,9 @@ function main() {
                     debug("trakt plugin is disabled");
                 }
             });
+
+            // plexwatch
+            PlexWWWatch.doit(parent_item_id);
         }
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
         "plugins/trakt.js",
         "plugins/rotten_tomatoes.js",
         "plugins/themoviedb.js",
+        "plugins/plexwwwatch.js",
         "main.js"
       ]
     }

--- a/options.html
+++ b/options.html
@@ -18,7 +18,7 @@
                 <label for="trailers_off">OFF</label>
             </div>
         </div>
-        
+
         <div class="field-row">
             <div class="label">Letterboxd Link:</div>
 
@@ -68,7 +68,7 @@
                 <label for="trakt_shows">SHOWS</label>
             </div>
         </div>
-          
+
         <div class="field-row">
             <div class="label">Random Picker:</div>
 
@@ -78,6 +78,14 @@
 
                 <input type="radio" id="random_off" name="random_picker" value="off"/>
                 <label for="random_off">OFF</label>
+            </div>
+        </div>
+
+        <div class="field-row" id="plexwwwatch">
+            <div class="label">PlexWWWatch url:</div>
+
+            <div class="field">
+                <input type="text" id="plexwwwatch_url">
             </div>
         </div>
 

--- a/options.js
+++ b/options.js
@@ -7,6 +7,7 @@ function saveOptions() {
     var trakt_movies = document.querySelector("input[name='trakt_movies']").checked;
     var trakt_shows = document.querySelector("input[name='trakt_shows']").checked;
     var random_picker = document.querySelector("input[name='random_picker']:checked").value;
+    var plexwwwatch_url = document.getElementById("plexwwwatch_url").value;
 
     var debug = document.querySelector("input[name='debug']:checked").value;
 
@@ -33,6 +34,7 @@ function saveOptions() {
     else {
         chrome.storage.sync.set({"trakt_shows": "off"});
     }
+    chrome.storage.sync.set({"plexwwwatch_url": plexwwwatch_url});
 
     chrome.storage.sync.set({"debug": debug});
 
@@ -145,6 +147,12 @@ function restoreOptions() {
         }
     });
 
+    chrome.storage.sync.get("plexwwwatch_url", function (result) {
+        if ("plexwwwatch_url" in result) {
+            document.getElementById("plexwwwatch_url").value = result.plexwwwatch_url;
+        }
+    });
+
     chrome.storage.sync.get("debug", function(result) {
         var radio_button;
         if (result["debug"]) {
@@ -206,6 +214,12 @@ function setDefaultOptions() {
     chrome.storage.sync.get("trakt_shows", function(result) {
         if (!("trakt_shows" in result)) {
             chrome.storage.sync.set({"trakt_shows": "on"});
+        }
+    });
+
+    chrome.storage.sync.get("plexwwwatch_url", function(result) {
+        if (!(plexwatch_url in result)) {
+            chrome.storage.sync.set({"plexwatch_url": ""});
         }
     });
 

--- a/plugins/plexwwwatch.js
+++ b/plugins/plexwwwatch.js
@@ -1,0 +1,102 @@
+PlexWWWatch = {
+    doit: function (ratingkey) {
+        PlexWWWatch.enabled(function (enabled) {
+            if (enabled) {
+                PlexWWWatch.getItem(ratingkey, function (item) {
+                    PlexWWWatch.createInfo(item.item);
+                });
+            }
+        });
+    },
+
+    enabled: function (cb) {
+        chrome.storage.sync.get("plexwwwatch_url", function (result) {
+            if ("plexwwwatch_url" in result && result.plexwwwatch_url !== "") {
+                cb(true);
+            } else {
+                cb(false);
+            }
+        });
+    },
+
+    getItem: function (ratingkey, cb) {
+        chrome.storage.sync.get("plexwwwatch_url", function (result) {
+            if ("plexwwwatch_url" in result) {
+                var url = result.plexwwwatch_url + "backend/plexWatchItem.php?item=" + ratingkey;
+                getAsyncJSON(url, function (error, item) {
+                    console.log("got json", error, item);
+                    if (!error) {
+                        cb(item);
+                    }
+                });
+            }
+        });
+    },
+
+    createInfo: function (item) {
+        var numWatches = PlexWWWatch.createNumWatchedElement(item);
+        var timeWatched = PlexWWWatch.createTimeWatchedElement(item);
+        var numCompleted = PlexWWWatch.createNumCompletedElement(item);
+
+
+        var container = document.getElementsByClassName("details-poster-container")[0];
+        container.appendChild(numWatches);
+        container.appendChild(timeWatched);
+        container.appendChild(numCompleted);
+    },
+
+    createNumWatchedElement: function (item) {
+        var numWatchedDiv = document.createElement("div");
+        numWatchedDiv.className = "item-available-at metadata-tags";
+        var text = "Never watched";
+        if (item.numWatches === 1) {
+             text = "Watched one time";
+        } else if (item.numWatches > 1) {
+            text = "Watched " + item.numWatches + " times";
+        }
+        numWatchedDiv.textContent = text;
+
+        return numWatchedDiv;
+    },
+
+    createTimeWatchedElement: function (item) {
+        var timeWatchedDiv = document.createElement("div");
+        timeWatchedDiv.className = "item-available-at metadata-tags";
+        var text = "Nothing watched";
+        if (item.timeWatched > 0) {
+            text = PlexWWWatch.secondsToDuration(item.timeWatched / 1000) + " watched";
+        }
+
+        timeWatchedDiv.textContent = text;
+
+        return timeWatchedDiv;
+    },
+
+    createNumCompletedElement: function (item) {
+        var numCompletedDiv = document.createElement("div");
+        numCompletedDiv.className = "item-available-at metadata-tags";
+        var text = "Never Completed";
+        if (item.numCompleted === 1) {
+             text = "Completed one time";
+        } else if (item.numCompleted > 1) {
+            text = "Completed " + item.numCompleted + " times";
+        }
+        numCompletedDiv.textContent = text;
+
+        return numCompletedDiv;
+    },
+
+    secondsToDuration: function (s) {
+        var h = parseInt(s / 3600, 10);
+        var m = parseInt(s / 60, 10) % 60;
+
+        var ret = "";
+        if (h > 0) {
+            ret = ret + h + " hr ";
+        }
+        if (m > 0) {
+            ret = ret + m + " min ";
+        }
+        return ret;
+    }
+};


### PR DESCRIPTION
If a [PlexWWWatch](https://github.com/Gyran/PlexWWWatch) installation exists watched info for episodes and movies can be shown.
In the options page, write the url to `http://host.com/PlexWWWatch/public/` and the info will be shown for episodes and movies.
