### PR TITLE
Bug fix for non-https connections blowing up extension at startup

### DIFF
--- a/main.js
+++ b/main.js
@@ -235,6 +235,9 @@ function getServerAddresses(requests_url, plex_token, callback) {
                 for (var j = 0; j < connections.length; j++) {
                     var connection = connections[j];
                     var uri = connection.hasAttribute("uri") ? connection.getAttribute("uri") : window.location.protocol + "//" + connection.getAttribute("address") + ":" + connection.getAttribute("port");
+                    if (uri.indexOf("https") < 0) {
+                        continue;
+                    }
                     var local = !connection.hasAttribute("uri") || connection.getAttribute("local") == 1;
                     task_counter += 1;
                     (function (machine_identifier, name, uri, access_token, local) {


### PR DESCRIPTION
I'm not sure why, but for some people (myself included), some non-https connections are getting returned from either the call to resources or servers. The actions subsequently performed with the non-https connection are causing the extension to blow up and not finish loading. 

I'm not much of a JS developer, so I don't know if this is the best way to fix this, but it has solved the problem for me.